### PR TITLE
Fix logger initialization

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,7 +20,7 @@ from models import get_model_response, MODELS, sanitize_user_input, validate_mod
 from utils import load_techniques, load_prompts
 from error_handlers import display_error_to_user
 from exceptions import APIError, ValidationError, ModelError, PromptInjectionError
-from logging_config import setup_logging, logger
+from logging_config import setup_logging, get_logger
 import os
 import mimetypes
 #import speech_recognition as sr  # For speech-to-text
@@ -32,6 +32,7 @@ import time
 
 # Initialize logging
 setup_logging()
+logger = get_logger(__name__)
 
 # Initialize OpenAI client
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))


### PR DESCRIPTION
## Summary
- update app to use `get_logger` instead of importing a missing logger
- initialize the logger in `app.py`

Codex was used to review the repository, modify the file with `apply_patch`, and run the tests and linters. The tests failed because dependencies like `streamlit` and `openai` are unavailable in the environment, and `flake8` could not run since it's not installed.


------
https://chatgpt.com/codex/tasks/task_e_6883dd9c04c88328b64a8bb0b6733eef